### PR TITLE
Add MoeScale Multi SMTP bundle

### DIFF
--- a/MoeScaleMultiSmtpBundle/Config/services.php
+++ b/MoeScaleMultiSmtpBundle/Config/services.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
+use MauticPlugin\MoeScaleMultiSmtpBundle\Mailer\Transport\MultiSmtpTransportFactory;
+use Mautic\EmailBundle\Mailer\Transport\TransportFactory as BaseTransportFactory;
+
+return function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->public();
+
+    $services->load('MauticPlugin\\MoeScaleMultiSmtpBundle\\', '../')
+        ->exclude('../{'.implode(',', MauticCoreExtension::DEFAULT_EXCLUDES).'}');
+
+    $services->set(MultiSmtpTransportFactory::class)
+        ->decorate(BaseTransportFactory::class);
+};

--- a/MoeScaleMultiSmtpBundle/DependencyInjection/MoeScaleMultiSmtpExtension.php
+++ b/MoeScaleMultiSmtpBundle/DependencyInjection/MoeScaleMultiSmtpExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MoeScaleMultiSmtpBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+class MoeScaleMultiSmtpExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../Config'));
+        $loader->load('services.php');
+    }
+}

--- a/MoeScaleMultiSmtpBundle/Mailer/Transport/MultiSmtpTransport.php
+++ b/MoeScaleMultiSmtpBundle/Mailer/Transport/MultiSmtpTransport.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MoeScaleMultiSmtpBundle\Mailer\Transport;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+
+class MultiSmtpTransport implements TransportInterface
+{
+    private static int $counter = 0;
+
+    public function __construct(
+        private Connection $connection,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+    {
+        $servers = $this->fetchServers();
+        if (0 === count($servers)) {
+            throw new \RuntimeException('No enabled SMTP servers found.');
+        }
+
+        $index = self::$counter % count($servers);
+        self::$counter++;
+        $server = $servers[$index];
+
+        $dsn = $this->buildDsn($server);
+        $transport = Transport::fromDsn($dsn);
+
+        try {
+            return $transport->send($message, $envelope);
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->error(sprintf('SMTP send failed for %s: %s', $server['server'], $e->getMessage()));
+            throw $e;
+        }
+    }
+
+    public function __toString(): string
+    {
+        return 'multismtp://';
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchServers(): array
+    {
+        $sql = 'SELECT * FROM smtp_servers WHERE enabled = 1 ORDER BY id';
+        try {
+            return $this->connection->fetchAllAssociative($sql);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed fetching SMTP servers: '.$e->getMessage());
+
+            return [];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $server
+     */
+    private function buildDsn(array $server): string
+    {
+        $scheme = 'smtp';
+        $user = $server['user_name'];
+        $pass = $server['password'] ?? '';
+        $host = $server['server'];
+        $port = (int) $server['port'];
+        $options = [];
+        if (!empty($server['encryption']) && 'none' !== $server['encryption']) {
+            $options['encryption'] = $server['encryption'];
+        }
+        if (!empty($server['auth_mode'])) {
+            $options['auth_mode'] = $server['auth_mode'];
+        }
+
+        $dsn = sprintf('%s://%s:%s@%s:%d', $scheme, urlencode((string) $user), urlencode((string) $pass), $host, $port);
+        if (!empty($options)) {
+            $dsn .= '?'.http_build_query($options);
+        }
+
+        return $dsn;
+    }
+}

--- a/MoeScaleMultiSmtpBundle/Mailer/Transport/MultiSmtpTransportFactory.php
+++ b/MoeScaleMultiSmtpBundle/Mailer/Transport/MultiSmtpTransportFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MoeScaleMultiSmtpBundle\Mailer\Transport;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mailer\Transport\Transports;
+use Mautic\EmailBundle\Mailer\Transport\TransportFactory as BaseTransportFactory;
+
+class MultiSmtpTransportFactory
+{
+    public function __construct(
+        private BaseTransportFactory $inner,
+        private Connection $connection,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $dsns
+     */
+    public function fromStrings(array $dsns): Transports
+    {
+        return $this->inner->fromStrings($dsns);
+    }
+
+    public function fromString(string $dsn): TransportInterface
+    {
+        $dsnObj = Dsn::fromString($dsn);
+        if ('multismtp' === $dsnObj->getScheme()) {
+            return new MultiSmtpTransport($this->connection, $this->logger);
+        }
+
+        return $this->inner->fromString($dsn);
+    }
+
+    public function fromDsnObject(Dsn $dsn): TransportInterface
+    {
+        if ('multismtp' === $dsn->getScheme()) {
+            return new MultiSmtpTransport($this->connection, $this->logger);
+        }
+
+        return $this->inner->fromDsnObject($dsn);
+    }
+}

--- a/MoeScaleMultiSmtpBundle/MoeScaleMultiSmtpBundle.php
+++ b/MoeScaleMultiSmtpBundle/MoeScaleMultiSmtpBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MauticPlugin\MoeScaleMultiSmtpBundle;
+
+use Mautic\PluginBundle\Bundle\PluginBundleBase;
+
+class MoeScaleMultiSmtpBundle extends PluginBundleBase
+{
+}

--- a/MoeScaleMultiSmtpBundle/README.md
+++ b/MoeScaleMultiSmtpBundle/README.md
@@ -1,0 +1,15 @@
+# MoeScale Multi SMTP Bundle
+
+This plugin provides dynamic SMTP rotation for Mautic v6. Outbound emails are distributed evenly across SMTP servers defined in the `smtp_servers` table.
+
+## Installation
+1. Copy the `MoeScaleMultiSmtpBundle` directory into Mautic's `/plugins` directory.
+2. Run the following commands from the Mautic root:
+   ```bash
+   php bin/console cache:clear
+   php bin/console mautic:plugins:reload
+   ```
+3. In **Configuration > Email Settings**, set the **Mailer DSN** to `multismtp://default` and save.
+4. Add your SMTP server records into the `smtp_servers` table.
+
+The plugin will automatically rotate between enabled SMTP servers on every email send.

--- a/MoeScaleMultiSmtpBundle/composer.json
+++ b/MoeScaleMultiSmtpBundle/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "moescale/multi-smtp-bundle",
+    "description": "Dynamic SMTP rotation for Mautic v6",
+    "type": "mautic-plugin",
+    "extra": {
+        "install-directory-name": "MoeScaleMultiSmtpBundle"
+    },
+    "require": {
+        "mautic/core-lib": "^7.0"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -19,14 +19,18 @@ The goal is to:
 - Seamless integration with Mautic's email sending workflow
 
 ## Status
-Work in progress. Contributions and suggestions are welcome!
+This repository contains the source code of the **MoeScale Multi SMTP Bundle**.
+Copy the `MoeScaleMultiSmtpBundle` directory from this repo into your Mautic
+`plugins` directory and run `php bin/console cache:clear` followed by
+`php bin/console mautic:plugins:reload`.
 
-## Getting Started
-1. Clone this repository
-2. Follow the instructions (to be added) for installing the plugin into your Mautic instance
+In Mautic's configuration set the **Mailer DSN** to `multismtp://default`.
+Add your SMTP server details into the `smtp_servers` table and emails will be
+evenly rotated across them.
 
 ## Inspiration
 Inspired by the `MauticEvenlyDistributesSmtpBundle`, this plugin aims to provide a scalable, database-driven approach to SMTP server distribution in Mautic.
 
 ## License
 MIT
+


### PR DESCRIPTION
## Summary
- implement new plugin `MoeScaleMultiSmtpBundle`
- add multi SMTP transport that rotates among enabled records in `smtp_servers`
- register transport factory decorator
- provide installation instructions in README files

## Testing
- `php -l MoeScaleMultiSmtpBundle/Config/services.php`
- `php -l MoeScaleMultiSmtpBundle/DependencyInjection/MoeScaleMultiSmtpExtension.php`
- `php -l MoeScaleMultiSmtpBundle/Mailer/Transport/MultiSmtpTransportFactory.php`
- `php -l MoeScaleMultiSmtpBundle/Mailer/Transport/MultiSmtpTransport.php`


------
https://chatgpt.com/codex/tasks/task_e_68895fac3e50832d8da953d9cc3e9626